### PR TITLE
Shallow head sets and board

### DIFF
--- a/client/src/assets/styles/index.scss
+++ b/client/src/assets/styles/index.scss
@@ -15,6 +15,7 @@ header {
   background-color: $lightgray;
   margin-bottom: 2rem;
   text-align: center;
+  white-space: nowrap;
 
   > * {
     display: inline-block;

--- a/client/src/components/GameBoard.js
+++ b/client/src/components/GameBoard.js
@@ -10,11 +10,10 @@ const GameBoard = (props) => {
   let styleId;
   const squares = [];
 
-  for (let r = 0; r < GRID_SIZE; r++) {
-    for (let c = 0; c < GRID_SIZE; c++) {
-      if (props.board[r] && props.board[r][c] && props.board[r][c].snake) {
-        status = props.board[r][c].snake.status;
-        styleId = props.board[r][c].snake.styleId;
+  for (let n = 0; n < GRID_SIZE * GRID_SIZE; n++) {
+      if (props.board[n] && props.board[n].snake) {
+        status = props.board[n].snake.status;
+        styleId = props.board[n].snake.styleId;
       } else {
         status = 'empty';
         styleId = undefined;
@@ -22,14 +21,12 @@ const GameBoard = (props) => {
 
       squares.push(
         <Square
-          col={c}
-          key={(r * GRID_SIZE) + c}
-          row={r}
+          key={n}
+          number={n}
           status={status}
           styleId={styleId}
         />,
       );
-    }
   }
 
   return (

--- a/client/src/components/Square.js
+++ b/client/src/components/Square.js
@@ -1,18 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Square = (props) => {
-  return (
-    <div
-      className={`square ${props.status} id-${props.styleId}`}
-      id={`r${props.row}c${props.col}`}
-    />
-  );
-};
+const Square = props => (
+  <div
+    className={`square ${props.status} id-${props.styleId}`}
+    id={props.number}
+  />
+);
 
 Square.propTypes = {
-  col: PropTypes.number.isRequired,
-  row: PropTypes.number.isRequired,
+  number: PropTypes.number.isRequired,
   status: PropTypes.string,
   styleId: PropTypes.number,
 };

--- a/client/src/redux/board/boardHelpers.js
+++ b/client/src/redux/board/boardHelpers.js
@@ -1,5 +1,3 @@
-import merge from 'lodash/merge';
-
 import store from '../store';
 
 import * as headSetHelpers from '../headSet/headSetHelpers';
@@ -16,7 +14,7 @@ export const aggregateBoards = (mostRecentTu) => {
 
   let i = mostRecentTu - (length - 1);
   while (i <= mostRecentTu) {
-    aggregatedBoard = merge(aggregatedBoard, headSets[i]);
+    aggregatedBoard = { ...aggregatedBoard, ...headSets[i] };
     i += 1;
   }
 
@@ -47,14 +45,14 @@ export const aggregateOwnSnake = (mostRecentTu) => {
 };
 
 export const getInitialBoard = () => (
-  merge(aggregateBoards(constants.INITIAL_TU), aggregateOwnSnake(constants.INITIAL_TU))
+  { ...aggregateBoards(constants.INITIAL_TU), ...aggregateOwnSnake(constants.INITIAL_TU) }
 );
 
 export const buildNextBoard = () => {
   const state = store.getState();
   const tu = state.info.tu;
 
-  const newBoard = merge(aggregateBoards(tu), aggregateOwnSnake(tu));
+  const newBoard = { ...aggregateBoards(tu), ...aggregateOwnSnake(tu) };
 
   const snakesObj = helpers.deepClone(state.snakes);
   const snakeIds = Object.keys(snakesObj);

--- a/client/src/redux/headSet/headSetHelpers.js
+++ b/client/src/redux/headSet/headSetHelpers.js
@@ -7,12 +7,12 @@ import * as constants from '../../constants';
 
 // tus, rows, columns as keys
 
-export const addCoordinatesMutate = (headSet, coords, snake, snakeId) => {
-  if (headSet[coords.row] === undefined) {
-    headSet[coords.row] = {};
-  }
+export const coordsToSquareNumber = coords => (
+  (coords.row * constants.GRID_SIZE) + coords.column
+);
 
-  headSet[coords.row][coords.column] = {
+export const addCoordinatesMutate = (headSet, coords, snake, snakeId) => {
+  headSet[coordsToSquareNumber(coords)] = {
     snake,
     id: snakeId,
   };

--- a/client/src/redux/snake/snakeActionCreators.js
+++ b/client/src/redux/snake/snakeActionCreators.js
@@ -1,5 +1,3 @@
-import merge from 'lodash/merge';
-
 import store from '../store';
 
 import * as actionTypes from '../actionTypes';
@@ -108,7 +106,10 @@ export const checkForCollisions = id => (
       ownHead = ownSnake.positions.byKey[tuCounter];
 
       // compare own head to other snakes and rest of own body
-      board = merge(boardHelpers.aggregateBoards(tuCounter), boardHelpers.aggregateOwnSnake(tuCounter - 1));
+      board = {
+        ...boardHelpers.aggregateBoards(tuCounter),
+        ...boardHelpers.aggregateOwnSnake(tuCounter - 1),
+      };
       length = snakeHelpers.getSnakeLength(tuCounter);
       squareNumber = headSetHelpers.coordsToSquareNumber(ownHead);
 


### PR DESCRIPTION
Instead of storing snake positions in head sets and boards with rows and columns (`board.row.column`), rows and columns are converted into square numbers: `sqNum = row * GRID_SIZE + column`.  This makes head sets and boards shallow objects which are easier to manage (no nested loops) and merge (shallow merge with spread operator).