### PR TITLE
Collision point fix

### DIFF
--- a/client/src/redux/actionTypes.js
+++ b/client/src/redux/actionTypes.js
@@ -1,6 +1,7 @@
 // headSets
 export const UPDATE_HEAD_SETS = 'UPDATE_HEAD_SETS';
 export const RESET_HEAD_SETS = 'RESET_HEAD_SETS';
+export const PATCH_HEAD_SET = 'PATCH_HEAD_SET'; // fix overwritten head
 
 // board
 export const GET_INITIAL_BOARD = 'GET_INITIAL_BOARD';

--- a/client/src/redux/headSet/headSetActionCreators.js
+++ b/client/src/redux/headSet/headSetActionCreators.js
@@ -7,6 +7,14 @@ export const updateHeadSets = (id, snake, gap) => ({
   type: actionTypes.UPDATE_HEAD_SETS,
 });
 
+export const patchHeadSet = (tu, sqNum, id, snake) => ({
+  tu,
+  sqNum,
+  id,
+  snake,
+  type: actionTypes.PATCH_HEAD_SET,
+});
+
 export const resetHeadSets = () => ({
   type: actionTypes.RESET_HEAD_SETS,
 });

--- a/client/src/redux/headSet/headSetActionCreators.js
+++ b/client/src/redux/headSet/headSetActionCreators.js
@@ -7,11 +7,10 @@ export const updateHeadSets = (id, snake, gap) => ({
   type: actionTypes.UPDATE_HEAD_SETS,
 });
 
-export const patchHeadSet = (tu, sqNum, id, snake) => ({
+export const patchHeadSet = (tu, sqNum, id) => ({
   tu,
   sqNum,
   id,
-  snake,
   type: actionTypes.PATCH_HEAD_SET,
 });
 

--- a/client/src/redux/headSet/headSetHelpers.js
+++ b/client/src/redux/headSet/headSetHelpers.js
@@ -11,10 +11,22 @@ export const coordsToSquareNumber = coords => (
   (coords.row * constants.GRID_SIZE) + coords.column
 );
 
-export const addCoordinatesMutate = (headSet, coords, snake, snakeId) => {
+export const addCoordinatesMutate = (headSet, coords, snake, id) => {
   headSet[coordsToSquareNumber(coords)] = {
     snake,
-    id: snakeId,
+    id,
+  };
+};
+
+export const patchHeadSetMutate = (headSets, tu, sqNum, snake, id) => {
+  // don't patch if out of current TU range
+  if (tu < headSets.oldest || tu > headSets.newest) {
+    return;
+  }
+
+  headSets.byKey[tu][sqNum] = {
+    snake,
+    id,
   };
 };
 

--- a/client/src/redux/headSet/headSetHelpers.js
+++ b/client/src/redux/headSet/headSetHelpers.js
@@ -18,14 +18,16 @@ export const addCoordinatesMutate = (headSet, coords, snake, id) => {
   };
 };
 
-export const patchHeadSetMutate = (headSets, tu, sqNum, snake, id) => {
+export const patchHeadSetMutate = (headSets, tu, sqNum, id) => {
   // don't patch if out of current TU range
   if (tu < headSets.oldest || tu > headSets.newest) {
     return;
   }
 
+  const snakes = store.getState().snakes;
+
   headSets.byKey[tu][sqNum] = {
-    snake,
+    snake: snakes[id],
     id,
   };
 };

--- a/client/src/redux/headSet/headSetReducer.js
+++ b/client/src/redux/headSet/headSetReducer.js
@@ -23,6 +23,13 @@ export default function headSetReducer(state = defaultState, action) {
 
       return newState;
     }
+    case actionTypes.PATCH_HEAD_SET: {
+      const newState = helpers.deepClone(state);
+
+      headSetHelpers.patchHeadSetMutate(newState, action.tu, action.sqNum, action.id);
+
+      return newState;
+    }
     case actionTypes.RESET_HEAD_SETS: {
       return defaultState;
     }

--- a/client/src/redux/p2p/p2pActionCreators.js
+++ b/client/src/redux/p2p/p2pActionCreators.js
@@ -3,6 +3,7 @@ import * as constants from '../../constants';
 import * as actionTypes from '../actionTypes';
 
 import * as metaActions from '../metaActionCreators';
+import * as headSetActions from '../headSet/headSetActionCreators';
 import * as infoActions from '../info/infoActionCreators';
 import * as snakeActions from '../snake/snakeActionCreators';
 
@@ -111,6 +112,17 @@ export const p2pBroadcastSnakeData = () => {
   }
 };
 
+export const p2pBroadcastPatch = (tu, sqNum, id, snake) => {
+  p2pBroadcast({
+    patch: {
+      tu,
+      sqNum,
+      id,
+      snake,
+    },
+  });
+};
+
 export const p2pKillPeerSnake = id => (
   (dispatch) => {
     dispatch(snakeActions.changeSnakeStatus(id, constants.SNAKE_STATUS_DEAD));
@@ -168,6 +180,9 @@ export const p2pSetDataListener = (connection, dispatch) => {
             const username = p2pHelpers.getUsername(data.winnerId);
             dispatch(infoActions.updateWinner(username));
           }
+        } else if (data.patch || data.patch === '') {
+          const info = data.patch;
+          dispatch(headSetActions.patchHeadSet(info.tu, info.sqNum, info.id, info.snake));
         } else {
           // pregame and playing: receive snake data from peers
           dispatch(metaActions.receiveSnakeData(connection.peer, data));

--- a/client/src/redux/p2p/p2pActionCreators.js
+++ b/client/src/redux/p2p/p2pActionCreators.js
@@ -181,7 +181,7 @@ export const p2pSetDataListener = (connection, dispatch) => {
           }
         } else if (data.patch || data.patch === '') {
           const info = data.patch;
-          dispatch(headSetActions.patchHeadSet(info.tu, info.sqNum, info.id, info.snake));
+          dispatch(headSetActions.patchHeadSet(info.tu, info.sqNum, info.id));
         } else {
           // pregame and playing: receive snake data from peers
           dispatch(metaActions.receiveSnakeData(connection.peer, data));

--- a/client/src/redux/p2p/p2pActionCreators.js
+++ b/client/src/redux/p2p/p2pActionCreators.js
@@ -112,13 +112,12 @@ export const p2pBroadcastSnakeData = () => {
   }
 };
 
-export const p2pBroadcastPatch = (tu, sqNum, id, snake) => {
+export const p2pBroadcastPatch = (tu, sqNum, id) => {
   p2pBroadcast({
     patch: {
       tu,
       sqNum,
       id,
-      snake,
     },
   });
 };

--- a/client/src/redux/snake/snakeActionCreators.js
+++ b/client/src/redux/snake/snakeActionCreators.js
@@ -65,7 +65,7 @@ export const writeOwnSnakePosition = id => (
 
     newSnake.positions.byKey = {};
     newSnake.positions.byKey[`${lastTu + 1}`] = coords;
-    newSnake.positions.byIndex = [`${lastTu + 1}`];
+    newSnake.positions.byIndex = [ `${lastTu + 1}` ];
 
     dispatch(updateSnakeData(id, newSnake));
     p2pActions.p2pBroadcastSnakeData();
@@ -124,8 +124,11 @@ export const checkForCollisions = id => (
 
         if (collisionType === constants.COLLISION_TYPE_HEAD_ON_HEAD) {
           // other snake is also dead
-          dispatch(changeSnakeStatus(board[squareNumber].id, constants.SNAKE_STATUS_DEAD));
-          p2pActions.p2pBroadcast(board[squareNumber].snake);
+          dispatch(p2pActions.p2pKillPeerSnake(board[squareNumber].id));
+        } else {
+          // tell peers to patch this head set to make sure other snake was not
+          // overwritten by your dead snake (leaving a gap in the snake's body)
+          p2pActions.p2pBroadcastPatch(tuCounter, squareNumber, board[squareNumber].id);
         }
 
         dispatch(checkForGameOver());


### PR DESCRIPTION
Every time a snake dies in a collision that isn't a head-to-head collision, the snake that detects the collision broadcasts a message to the other peers instructing them to patch their head sets so that the surviving snake occupies that square instead of the snake that has died.  This prevents the collision point from being a blank space in the body of the surviving snake.