### PR TITLE
change deployment url to ouroboros-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ real-time, direct peer-to-peer data exchange over the WebRTC data channel.
 ## Deployment
 
 To read about the engineering challenges of building Ouroboros and to play the
-game, visit [https://ouroboros-game.herokuapp.com/](https://ouroboros-game.herokuapp.com/).
+game, visit [https://ouroboros-app.herokuapp.com/](https://ouroboros-app.herokuapp.com/).
 
 ## Running Locally
 


### PR DESCRIPTION
We have a working deployment at http://ouroboros-app.herokuapp.com/ but not at http://ouroboros-game.herokuapp.com/, so I'm switching the url in the readme to the former.